### PR TITLE
Fix render card issue, add Action.Execute type

### DIFF
--- a/actions.go
+++ b/actions.go
@@ -42,6 +42,43 @@ type ActionSubmit struct {
 
 func (n *ActionSubmit) prepare() error {
 	n.Type = ActionSubmitType
+	for _, e := range n.Fallback {
+		if err := e.prepare(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ActionExecute gathers input fields, merges with optional data field, and sends an event to the client.
+// Clients process the event by sending an Invoke activity of type adaptiveCard/action to the target Bot.
+// See https://adaptivecards.io/explorer/Action.Execute.html for more details.
+//
+// It requires a minimum version of 1.4.
+type ActionExecute struct {
+	Type             string      `json:"type"` // required
+	Verb             string      `json:"verb,omitempty"`
+	Data             interface{} `json:"data,omitempty"`
+	AssociatedInputs string      `json:"associatedInputs,omitempty"`
+
+	// inherited
+	Title     string            `json:"title,omitempty"`
+	IconURL   string            `json:"iconUrl,omitempty"`
+	Style     string            `json:"style,omitempty"`
+	Tooltip   string            `json:"tooltip,omitempty"`
+	IsEnabled *bool             `json:"isEnabled,omitempty"`
+	Fallback  []Node            `json:"fallback,omitempty"`
+	Mode      string            `json:"mode,omitempty"` // primary, secondary
+	Requires  map[string]string `json:"requires,omitempty"`
+}
+
+func (n *ActionExecute) prepare() error {
+	n.Type = ActionExecuteType
+	for _, e := range n.Fallback {
+		if err := e.prepare(); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 

--- a/cards.go
+++ b/cards.go
@@ -8,15 +8,16 @@ import (
 const (
 	// DefaultSchema is card schema value by default
 	DefaultSchema = "http://adaptivecards.io/schemas/adaptive-card.json"
-	// Version1 is cards verstion 1.0
+	// Version1 is cards version 1.0
 	Version1 = "1.0"
-	// Version11 is cards verstion 1.1
+	// Version11 is cards version 1.1
 	Version11 = "1.1"
-	// Version12 is cards verstion 1.2
+	// Version12 is cards version 1.2
 	Version12 = "1.2"
-	// Version13 is cards verstion 1.3.
-	// Warning maybe not supported by bot framework!
+	// Version13 is cards version 1.3.
 	Version13 = "1.3"
+	// Version14 is cards version 1.4.
+	Version14 = "1.4"
 
 	// Types
 
@@ -48,6 +49,8 @@ const (
 	ActionShowCardType = "Action.ShowCard"
 	// ActionSubmitType is type for Action.Submit
 	ActionSubmitType = "Action.Submit"
+	// ActionExecuteType is type for Action.Execute
+	ActionExecuteType = "Action.Execute"
 	// ActionOpenURLType is type for Action.OpenUrl
 	ActionOpenURLType = "Action.OpenUrl"
 	// ActionToggleVisibilityType is type for Action.ToggleVisibility

--- a/cards.go
+++ b/cards.go
@@ -67,6 +67,11 @@ const (
 	InputChoiceSetType = "Input.ChoiceSet"
 	// InputToggleType is type for Input.Toggle
 	InputToggleType = "Input.Toggle"
+
+	TableType       = "Table"
+	TableColumnType = "TableColumnDefinition"
+	TableRowType    = "TableRow"
+	TableCellType   = "TableCell"
 )
 
 // Node is card element

--- a/containers.go
+++ b/containers.go
@@ -76,6 +76,7 @@ type ColumnSet struct {
 	// inherited
 	Fallback  []Node            `json:"fallback,omitempty"`
 	Height    string            `json:"height,omitempty"`
+	Separator *bool             `json:"separator,omitempty"`
 	Spacing   string            `json:"spacing,omitempty"`
 	ID        string            `json:"id,omitempty"`
 	IsVisible *bool             `json:"isVisible,omitempty"`

--- a/elements.go
+++ b/elements.go
@@ -159,3 +159,82 @@ func (t *TextRun) prepare() error {
 	}
 	return nil
 }
+
+type Table struct {
+	Type              string        `json:"type"`
+	Columns           []TableColumn `json:"columns,omitempty"`
+	Rows              []TableRow    `json:"rows,omitempty"`
+	GridStyle         *string       `json:"gridStyle,omitempty"`
+	FirstRowAsHeaders *bool         `json:"firstRowAsHeaders,omitempty"`
+	// inherited
+	Fallback  []Node            `json:"fallback,omitempty"`
+	Height    string            `json:"height,omitempty"`
+	Separator *bool             `json:"separator,omitempty"`
+	Spacing   string            `json:"spacing,omitempty"`
+	ID        string            `json:"id,omitempty"`
+	IsVisible *bool             `json:"isVisible,omitempty"`
+	Requires  map[string]string `json:"requires,omitempty"`
+}
+
+func (t *Table) prepare() error {
+	t.Type = TableType
+	if len(t.Rows) == 0 {
+		return errors.New("Table must have rows")
+	}
+	if len(t.Columns) == 0 {
+		return errors.New("Table must have columns")
+	}
+	for idx := range t.Rows {
+		if err := t.Rows[idx].prepare(); err != nil {
+			return err
+		}
+	}
+	for idx := range t.Columns {
+		if err := t.Columns[idx].prepare(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+type TableColumn struct {
+	Type                           string  `json:"type"`
+	Width                          *int    `json:"width,omitempty"`
+	HorizontalCellContentAlignment *string `json:"horizontalCellContentAlignment,omitempty"`
+	VerticalCellContentAlignment   *string `json:"verticalCellContentAlignment,omitempty"`
+}
+
+func (t *TableColumn) prepare() error {
+	t.Type = TableColumnType
+	return nil
+}
+
+type TableRow struct {
+	Type  string      `json:"type"`
+	Cells []TableCell `json:"cells,omitempty"`
+}
+
+func (t *TableRow) prepare() error {
+	t.Type = TableRowType
+	for idx := range t.Cells {
+		if err := t.Cells[idx].prepare(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+type TableCell struct {
+	Type  string `json:"type"`
+	Items []Node `json:"items,omitempty"`
+}
+
+func (t *TableCell) prepare() error {
+	t.Type = TableCellType
+	for idx := range t.Items {
+		if err := t.Items[idx].prepare(); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/inputs.go
+++ b/inputs.go
@@ -31,6 +31,9 @@ func (n *InputText) prepare() error {
 	if n.ID == "" {
 		return errors.New("InputText id is required")
 	}
+	if err := n.InlineAction.prepare(); err != nil {
+		return err
+	}
 	return nil
 }
 


### PR DESCRIPTION
**Description**

- Fix render card issue - the `prepare()` method was not called to the associated Nodes.
- Since the version 1.4 of Adaptive Cards, there is a new type called `Action.Execute`. This PR adds a basic support for it.